### PR TITLE
Use iter instead of getiterator for Python 3 compatibility

### DIFF
--- a/mdlightbox.py
+++ b/mdlightbox.py
@@ -25,7 +25,10 @@ class LightboxImagesTreeprocessor(Treeprocessor):
     def run(self, root):
         parent_map = {c:p for p in root.iter() for c in p}
         i = 0
-        images = root.getiterator("img")
+        try:
+            images = root.iter("img")
+        except AttributeError:
+            images = root.getiterator("img")
         for image in images:
             desc = image.attrib["alt"]
             h = self.hidden_re.match(desc)


### PR DESCRIPTION
Fixes: https://github.com/aleksan4eg/markdown-lightbox/issues/1