### PR TITLE
Fix deprecation warnings with Python-Markdown 3.x

### DIFF
--- a/mdlightbox.py
+++ b/mdlightbox.py
@@ -70,9 +70,10 @@ class LightboxImagesExtension(Extension):
     def __init__(self, **kwargs):
         self.config = {'group' : [True,"group all images into same lightbox"] }
         super(LightboxImagesExtension, self).__init__(**kwargs)
-    def extendMarkdown(self, md, md_globals):
-        lightbox_images = LightboxImagesTreeprocessor(md, self.getConfig('group'))
-        md.treeprocessors.add("lightbox", lightbox_images, "_end")
+    def extendMarkdown(self, md):
+        lightbox_images = LightboxImagesTreeprocessor(
+            md, self.getConfig('group'))
+        md.treeprocessors.register(lightbox_images, "lightbox", 20)
         md.registerExtension(self)
 
 

--- a/mdlightbox.py
+++ b/mdlightbox.py
@@ -15,15 +15,18 @@ from copy import copy
 GROUP_RE = r'(^(@\{(?P<lightbox>.+)\})(?P<description>.*))'
 HIDDEN_RE = r'(^(!)(?P<description>.*))'
 
+
 class LightboxImagesTreeprocessor(Treeprocessor):
     """ Lightbox Images Treeprocessor """
-    def __init__(self, md, group = True):
+
+    def __init__(self, md, group=True):
         Treeprocessor.__init__(self, md)
         self.group_re = re.compile(GROUP_RE)
         self.hidden_re = re.compile(HIDDEN_RE)
         self.group = group
+
     def run(self, root):
-        parent_map = {c:p for p in root.iter() for c in p}
+        parent_map = {c: p for p in root.iter() for c in p}
         i = 0
         try:
             images = root.iter("img")
@@ -49,17 +52,16 @@ class LightboxImagesTreeprocessor(Treeprocessor):
             parent = parent_map[image]
             ix = list(parent).index(image)
             new_node = etree.Element('a')
-            new_node.set("href",image.attrib["src"])
+            new_node.set("href", image.attrib["src"])
             new_node.set("data-lightbox", lb)
-            new_node.set("data-title",desc)
+            new_node.set("data-title", desc)
             new_node.tail = copy(image.tail)
             parent.insert(ix, new_node)
             parent.remove(image)
             image.tail = markdown.util.AtomicString("")
             if not hidden:
-                new_node.append(image) 
+                new_node.append(image)
             i += 1
-
 
 
 class LightboxImagesExtension(Extension):
@@ -67,15 +69,16 @@ class LightboxImagesExtension(Extension):
     LightboxImagesExtension
     Extension class for markdown
     """
+
     def __init__(self, **kwargs):
-        self.config = {'group' : [True,"group all images into same lightbox"] }
+        self.config = {'group': [True, "group all images into same lightbox"]}
         super(LightboxImagesExtension, self).__init__(**kwargs)
+
     def extendMarkdown(self, md):
         lightbox_images = LightboxImagesTreeprocessor(
             md, self.getConfig('group'))
         md.treeprocessors.register(lightbox_images, "lightbox", 20)
         md.registerExtension(self)
-
 
 
 def makeExtension(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     description='Markdown extension which turns images into lightbox',
     url='https://github.com/AliciaSchep/markdown-lightbox',
     py_modules=['mdlightbox'],
-    install_requires=['Markdown>=2.0'],
+    install_requires=['Markdown>=3.0'],
     classifiers=[
         'Topic :: Text Processing :: Markup :: HTML'
     ]

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='markdown-lightbox',
-    version='0.0.0',
+    version='1.0.0',
     author='Alicia Schep',
     author_email='aschep@gmail.com',
     description='Markdown extension which turns images into lightbox',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
-
-
 from setuptools import setup
+
 setup(
     name='markdown-lightbox',
     version='0.0.0',
@@ -15,7 +14,3 @@ setup(
         'Topic :: Text Processing :: Markup :: HTML'
     ]
 )
-
-
-
-


### PR DESCRIPTION
https://python-markdown.github.io/change_log/release-3.0/#md_globals-keyword-deprecated-from-extension-api 
https://python-markdown.github.io/change_log/release-3.0/#homegrown-ordereddict-has-been-replaced-with-a-purpose-built-registry

The priority number was arbitrarily chosen.